### PR TITLE
Убран нестандартный заголовок

### DIFF
--- a/src/basis/net.js
+++ b/src/basis/net.js
@@ -359,8 +359,7 @@
   */
   function setRequestHeaders(request, requestData){
     var headers = {
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-Powered-By': 'basis.js'
+      'X-Requested-With': 'XMLHttpRequest'
     };
 
     if (IS_METHOD_WITH_BODY.test(requestData.method)) 


### PR DESCRIPTION
При создании запросов к некоторым API, например [github](http://developer.github.com/v3/) разрешается только ограниченный набор заголовков. X-Powered-By в их число не входит и в итоге браузер заворачивает запрос. Здесь (https://github.com/just-boris/just-boris.github.com/blob/master/ru/index.html) лежит пример, в котором для обхода этого ограничения используется подмененный модуль basis.net. К сожалению, поскольку метод выставления заголовков приватный, я не смог найти способ переопределить только его. Поэтому для расширения возможностей фреймворка этот pull request
