### PR TITLE
b:svg;  `:` is allowed in attr names; touch support in devpanel template inspector

### DIFF
--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -482,6 +482,10 @@
       return result;
     },
 
+    query: function(path){
+      return Value.query(this, 'value.' + path);
+    },
+
    /**
     * @return {basis.data.DeferredValue}
     */
@@ -917,6 +921,7 @@
     fn.factory = FACTORY;
     fn.deferred = valueDeferredFactory;
     fn.compute = valueComputeFactory;
+    fn.query = valueQueryFactory;
     fn.pipe = valuePipeFactory;
     fn.as = valueAsFactory;
 
@@ -963,6 +968,17 @@
       value = factory(value);
       return value
         ? value.pipe(events, getter)
+        : value;
+    });
+  }
+
+  function valueQueryFactory(path){
+    var factory = this;
+
+    return chainValueFactory(function(value){
+      value = factory(value);
+      return value
+        ? value.query(path)
         : value;
     });
   }

--- a/src/basis/data/value.js
+++ b/src/basis/data/value.js
@@ -19,7 +19,6 @@
   var basisData = require('basis.data');
   var AbstractData = basisData.AbstractData;
   var Value = basisData.Value;
-  var ReadOnlyValue = basisData.ReadOnlyValue;
   var Expression = require('./Expression.js');
   var STATE = basisData.STATE;
 

--- a/src/devpanel/inspector/template-info/template/window.tmpl
+++ b/src/devpanel/inspector/template-info/template/window.tmpl
@@ -2,7 +2,7 @@
 <b:isolate/>
 <b:define name="upName" type="bool"/>
 
-<div class="window__wrapper" event-click="close" event-mousedown="stop-propagation" event-touchstart="stop-propagation" event-touchend="stop-propagation" basis-devpanel-ignore>
+<div class="window__wrapper" event-click="close" event-mousedown="stop-propagation prevent-default" basis-devpanel-ignore>
   <div{ddelement|ddtrigger} class="window">
     <div class="window__inner" event-click="stop-propagation">
       <div class="window__inner-wrapper">

--- a/src/devpanel/inspector/template-info/template/window.tmpl
+++ b/src/devpanel/inspector/template-info/template/window.tmpl
@@ -2,7 +2,7 @@
 <b:isolate/>
 <b:define name="upName" type="bool"/>
 
-<div class="window__wrapper" event-click="close" event-mousedown="stop-propagation prevent-default" basis-devpanel-ignore>
+<div class="window__wrapper" event-click="close" event-mousedown="stop-propagation" event-touchstart="stop-propagation" event-touchend="stop-propagation" basis-devpanel-ignore>
   <div{ddelement|ddtrigger} class="window">
     <div class="window__inner" event-click="stop-propagation">
       <div class="window__inner-wrapper">


### PR DESCRIPTION
- helps to debug when tablet device mode is on in chrome DevTools
- allows to select text with a mouse in the template inspector