### PR TITLE
basis.ui.popup: separate popup container is back

### DIFF
--- a/src/basis/ui/popup.js
+++ b/src/basis/ui/popup.js
@@ -330,7 +330,7 @@
   // async document.body ready
   basis.doc.body.ready(function(body){
     var popupContainer = document.createElement('div');
-    popupContainer.classList.add('popup-container');
+    popupContainer.setAttribute('data-dev-role', 'popup-container');
     body.appendChild(popupContainer);
 
     popupManager.body = popupContainer;

--- a/src/basis/ui/popup.js
+++ b/src/basis/ui/popup.js
@@ -329,11 +329,15 @@
 
   // async document.body ready
   basis.doc.body.ready(function(body){
-    popupManager.body = body;
+    var popupContainer = document.createElement('div');
+    popupContainer.classList.add('popup-container');
+    body.appendChild(popupContainer);
+
+    popupManager.body = popupContainer;
     popupManager.forEach(function(popup){
       if (!domUtils.parentOf(document, popup.element))
       {
-        body.appendChild(popup.element);
+        popupManager.body.appendChild(popup.element);
         popup.realign();
       }
     });


### PR DESCRIPTION
Inserting popups right into `<body>` caused all kinds of shenanigans in
Firefox, so I did a little Firefix.