### PR TITLE
fix for duplicate callbacks in service transport

### DIFF
--- a/src/basis/net/service.js
+++ b/src/basis/net/service.js
@@ -45,7 +45,8 @@
   var SERVICE_HANDLER = {
     start: function(service, request){
       this.inprogressRequests.push(request);
-      if (basis.array.add(this.inprogressTransports, request.transport))
+      if (basis.array.add(this.inprogressTransports, request.transport) &&
+          (!service.stoppedTransports || service.stoppedTransports.indexOf(request.transport) == -1))
         request.transport.addHandler(TRANSPORT_HANDLER, this);
     },
     complete: function(service, request){


### PR DESCRIPTION
take into account stopped transports to avoid error of duplicate callbacks