### PR TITLE
fixed oneFunctionProperty for false-value support

### DIFF
--- a/src/basis.js
+++ b/src/basis.js
@@ -1805,8 +1805,8 @@
           /** @cut */ result.__extend__ = create;
 
           for (var key in keys)
-            if (hasOwnProperty.call(keys, key) && keys[key])
-              result[key] = fn;
+            if (hasOwnProperty.call(keys, key))
+              result[key] = keys[key] ? fn : null; //todo: or maybe empty function?
         }
 
         return result;


### PR DESCRIPTION
это пример из документации:
https://github.com/basisjs/articles/blob/master/ru-RU/basis.Class.md#onefunctionproperty
из него видно, что oneFunctionProperty должна поддерживать false-значения у свойств, чтобы переопределять/убирать ранее установленную функцию