### PR TITLE
added forceApply to propertyDescriptors

### DIFF
--- a/src/basis/dom/wrapper.js
+++ b/src/basis/dom/wrapper.js
@@ -623,7 +623,10 @@
     propertyDescriptors: {
       owner: 'ownerChanged',
       parentNode: 'parentChanged',
-      childNodes: 'childNodesModified',
+      childNodes: {
+        forceApply: 'true',
+        events: 'childNodesModified'
+      },
       childNodesState: 'childNodesStateChanged',
       dataSource: 'dataSourceChanged',
       'getChildNodesDataset()': true,

--- a/test/spec/data/value.js
+++ b/test/spec/data/value.js
@@ -5,6 +5,7 @@ module.exports = {
   init: function(){
     var basis = window.basis.createSandbox();
 
+    var events = basis.require('basis.event');
     var Emitter = basis.require('basis.event').Emitter;
     var STATE = basis.require('basis.data').STATE;
     var Value = basis.require('basis.data').Value;
@@ -1155,6 +1156,36 @@ module.exports = {
               foo: 2
             });
             assert(targetState.value === 2);
+          }
+        },
+        {
+          name: 'should update value with force apply flag',
+          test: function(){
+            var target = new DataObject({
+              propertyDescriptors: {
+                arrayProperty: {
+                  events: 'arrayChanged',
+                  forceApply: true
+                }
+              },
+              arrayProperty: [],
+              emit_arrayChanged: events.create('arrayChanged'),
+              push: function(){
+                this.arrayProperty.push.apply(this.arrayProperty, arguments);
+                this.emit_arrayChanged();
+              }
+            });
+            var totalExec = 0;
+            var targetState = Value.query(target, 'arrayProperty').as(function(array){
+              totalExec++;
+              return array.length;
+            });
+
+            target.push(1, 2, 3);
+            assert(targetState.value === 3);
+            target.push(4, 5, 6);
+            assert(targetState.value === 6);
+            assert(totalExec === 3);
           }
         },
         {


### PR DESCRIPTION
Added `forceApply` flag to `propertyDescriptors`.
`forceApply` flag allows to bypass `Value#set` check that performing before emit `change` evenе .
Now we can make a `Value::query` to array properties.
