### PR TITLE
Fix wrong warning issues

### DIFF
--- a/src/basis/event.js
+++ b/src/basis/event.js
@@ -18,6 +18,9 @@
 
   var NULL_HANDLER = {};
   var events = {};
+  var warnOnDestroyWhileDestroing = function(){
+    /** @cut */ basis.dev.warn('Invoke `destroy` method is prohibited during object destroy.');
+  };  
   var warnOnDestroy = function(){
     /** @cut */ basis.dev.warn('Object had been destroyed before. Destroy method must not be called more than once.');
   };
@@ -264,6 +267,11 @@
     * @param {object=} context Context object.
     */
     removeHandler: function(callbacks, context){
+      // avoid warnings on trying to remove handler for destroyed instance
+      // since it droped all handlers
+      if (this.destroy === warnOnDestroy)
+        return;
+
       var cursor = this;
       var prev;
 
@@ -291,13 +299,16 @@
     */
     destroy: function(){
       // warn on destroy method call (only in debug mode)
-      this.destroy = warnOnDestroy;
+      this.destroy = warnOnDestroyWhileDestroing;
 
       // fire object destroy event handlers
       this.emit_destroy();
 
       // drop event handlers if any
       this.handler = null;
+
+      // no more events possible
+      this.destroy = warnOnDestroy;
     }
   });
 

--- a/src/basis/event.js
+++ b/src/basis/event.js
@@ -20,7 +20,7 @@
   var events = {};
   var warnOnDestroyWhileDestroing = function(){
     /** @cut */ basis.dev.warn('Invoke `destroy` method is prohibited during object destroy.');
-  };  
+  };
   var warnOnDestroy = function(){
     /** @cut */ basis.dev.warn('Object had been destroyed before. Destroy method must not be called more than once.');
   };

--- a/test/spec/dom.wrapper/satellite.js
+++ b/test/spec/dom.wrapper/satellite.js
@@ -2333,6 +2333,89 @@ module.exports = {
           ]
         }
       ]
+    },
+    {
+      name: 'edge cases',
+      test: [
+        {
+          name: 'should no warnings on node destroy with satellite that has a Value.from() instances',
+          test: function(){
+            var node = new Node({
+              satellite: {
+                foo: new Node()
+              }
+            });
+
+            Value.from(node.satellite.foo, 'ownerChanged', 'owner');
+
+            var warn = basis.dev.warn;
+            var warning = false;
+            try {
+              basis.dev.warn = function(message){
+                warning = message;
+              };
+
+              node.destroy();
+            } finally {
+              basis.dev.warn = warn;
+            }
+
+            assert(warning === false);
+          }
+        },
+        {
+          name: 'should no warnings on node destroy with satellite that has a Value.from().pipe() instances',
+          test: function(){
+            var node = new Node({
+              satellite: {
+                foo: new Node()
+              }
+            });
+
+            Value.from(node, 'satelliteChanged', 'satellite.foo').pipe('update', 'data.data');
+
+            var warn = basis.dev.warn;
+            var warning = false;
+            try {
+              basis.dev.warn = function(message){
+                warning = message;
+              };
+
+              node.satellite.foo.destroy();
+            } finally {
+              basis.dev.warn = warn;
+            }
+
+            assert(warning === false);
+          }
+        },
+        {
+          name: 'should no warnings on node destroy with satellite that has a Value.from().pipe() instances',
+          test: function(){
+            var node = new Node({
+              childNodes: [
+                new Node({
+                  selected: Value.factory('update', 'data.foo')
+                })
+              ]
+            });
+
+            var warn = basis.dev.warn;
+            var warning = false;
+            try {
+              basis.dev.warn = function(message){
+                warning = message;
+              };
+
+              node.firstChild.destroy();
+            } finally {
+              basis.dev.warn = warn;
+            }
+
+            assert(warning === false);
+          }
+        }
+      ]
     }
   ]
 };


### PR DESCRIPTION
- `Emitter` instances don't warn on handler removing when already destroed since it already drops all it's handlers
- `ReadOnlyValue` instances don't add destroy handler on its value since they can't drop value anyway (and shouldn't)
- prevent double handler removing for `Value.from()` instances