### PR TITLE
Relaxing some checks for ui:scroller

### DIFF
--- a/src/basis/ui/scroller.js
+++ b/src/basis/ui/scroller.js
@@ -740,7 +740,6 @@
       var scroller = this.scroller;
 
       if (
-          this.maxPositionX &&
           this.scrollX &&
           (scroller.viewportX < this.minPositionX || scroller.viewportX > this.maxPositionX)
         )
@@ -750,7 +749,6 @@
       }
 
       if (
-          this.maxPositionY &&
           this.scrollY &&
           (scroller.viewportY < this.minPositionY || scroller.viewportY > this.maxPositionY)
         )


### PR DESCRIPTION
Scroller content fixing was broken due to an erroneous check. maxPositionX and maxPositionY are defined in @init method and should not throw any errors.