### PR TITLE
basis.data.dataset: flush dataset on destroy and prevent further itemsChanged events

### DIFF
--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2447,9 +2447,6 @@
     var realEvent;
 
     function flushCache(cache){
-      if (cache === PREVENT_ACCUMULATIONS)
-        return;
-
       realEvent.call(cache.dataset, cache);
     }
 
@@ -2460,7 +2457,8 @@
         if (entry)
         {
           eventCacheCopy[datasetId] = null;
-          flushCache(entry);
+          if (entry !== PREVENT_ACCUMULATIONS)
+            flushCache(entry);
         }
       }
 
@@ -2604,10 +2602,12 @@
     }
 
     Dataset.preventAccumulations = function(dataset){
-      if (setStateCount) {
-        var entry = eventCache[dataset.basisObjectId];
+      var entry = eventCache[dataset.basisObjectId];
+      if (entry && entry !== PREVENT_ACCUMULATIONS)
+      {
+        var cache = eventCache[dataset.basisObjectId];
+        realEvent.call(cache.dataset, cache);
         eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
-        flushCache(entry);
       }
     };
 

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2095,8 +2095,6 @@
     * @destructor
     */
     destroy: function(){
-      Dataset.preventAccumulations(this);
-
       // inherit
       AbstractData.prototype.destroy.call(this);
 
@@ -2361,7 +2359,7 @@
     * @destructor
     */
     destroy: function(){
-      Dataset.flushDataset(this);
+      Dataset.preventAccumulations(this);
 
       this.clear();
 
@@ -2488,7 +2486,10 @@
       var cache = eventCache[datasetId];
 
       if (cache === PREVENT_ACCUMULATIONS)
+      {
+        realEvent.call(dataset, delta);
         return;
+      }
 
       if ((inserted && deleted) || (cache && cache.mixed))
       {
@@ -2603,21 +2604,11 @@
       flushAllDataset();
     }
 
-    Dataset.flushDataset = function(dataset){
-      var cache = eventCache[dataset.basisObjectId];
-      if (cache)
-        flushCache(cache);
-      eventCache[dataset.basisObjectId] = null;
-    };
-
     Dataset.preventAccumulations = function(dataset){
-      var entry = eventCache[dataset.basisObjectId];
-      if (entry && entry !== PREVENT_ACCUMULATIONS)
-      {
-        var cache = eventCache[dataset.basisObjectId];
+      var cache = eventCache[dataset.basisObjectId];
+      if (cache && cache !== PREVENT_ACCUMULATIONS)
         realEvent.call(cache.dataset, cache);
-        eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
-      }
+      eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
     };
 
     Dataset.setAccumulateState = function(state){

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2611,13 +2611,10 @@
     };
 
     Dataset.preventAccumulations = function(dataset){
-      var entry = eventCache[dataset.basisObjectId];
-      if (entry && entry !== PREVENT_ACCUMULATIONS)
-      {
-        var cache = eventCache[dataset.basisObjectId];
+      var cache = eventCache[dataset.basisObjectId];
+      if (cache && cache !== PREVENT_ACCUMULATIONS)
         realEvent.call(cache.dataset, cache);
-        eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
-      }
+      eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
     };
 
     Dataset.setAccumulateState = function(state){

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -1994,7 +1994,7 @@
       }
 
       // remove old items
-      if ((items = delta.deleted) && this.items_)
+      if (items = delta.deleted)
       {
         while (object = items[deleteCount])
         {
@@ -2361,6 +2361,8 @@
     * @destructor
     */
     destroy: function(){
+      Dataset.flushDataset(this);
+
       this.clear();
 
       // inherit
@@ -2600,6 +2602,13 @@
       proto.emit_itemsChanged = realEvent;
       flushAllDataset();
     }
+
+    Dataset.flushDataset = function(dataset){
+      var cache = eventCache[dataset.basisObjectId];
+      if (cache)
+        flushCache(cache);
+      eventCache[dataset.basisObjectId] = null;
+    };
 
     Dataset.preventAccumulations = function(dataset){
       var entry = eventCache[dataset.basisObjectId];

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2337,7 +2337,7 @@
     * Removes all items from dataset.
     */
     clear: function(){
-      Dataset.flushDataset(this);
+      Dataset.flushChanges(this);
 
       var deleted = this.getItems();
       var listenHandler = this.listen.item;
@@ -2603,7 +2603,7 @@
       flushAllDataset();
     }
 
-    Dataset.flushDataset = function(dataset){
+    Dataset.flushChanges = function(dataset){
       var cache = eventCache[dataset.basisObjectId];
       if (cache)
         flushCache(cache);

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -1994,7 +1994,7 @@
       }
 
       // remove old items
-      if (items = delta.deleted)
+      if ((items = delta.deleted) && this.items_)
       {
         while (object = items[deleteCount])
         {

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2337,6 +2337,8 @@
     * Removes all items from dataset.
     */
     clear: function(){
+      Dataset.flushDataset(this);
+
       var deleted = this.getItems();
       var listenHandler = this.listen.item;
       var delta;
@@ -2361,8 +2363,6 @@
     * @destructor
     */
     destroy: function(){
-      Dataset.flushDataset(this);
-
       this.clear();
 
       // inherit

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2095,6 +2095,8 @@
     * @destructor
     */
     destroy: function(){
+      Dataset.preventAccumulations(this);
+
       // inherit
       AbstractData.prototype.destroy.call(this);
 
@@ -2359,7 +2361,7 @@
     * @destructor
     */
     destroy: function(){
-      Dataset.preventAccumulations(this);
+      Dataset.flushDataset(this);
 
       this.clear();
 
@@ -2486,10 +2488,7 @@
       var cache = eventCache[datasetId];
 
       if (cache === PREVENT_ACCUMULATIONS)
-      {
-        realEvent.call(dataset, delta);
         return;
-      }
 
       if ((inserted && deleted) || (cache && cache.mixed))
       {
@@ -2604,11 +2603,21 @@
       flushAllDataset();
     }
 
-    Dataset.preventAccumulations = function(dataset){
+    Dataset.flushDataset = function(dataset){
       var cache = eventCache[dataset.basisObjectId];
-      if (cache && cache !== PREVENT_ACCUMULATIONS)
+      if (cache)
+        flushCache(cache);
+      eventCache[dataset.basisObjectId] = null;
+    };
+
+    Dataset.preventAccumulations = function(dataset){
+      var entry = eventCache[dataset.basisObjectId];
+      if (entry && entry !== PREVENT_ACCUMULATIONS)
+      {
+        var cache = eventCache[dataset.basisObjectId];
         realEvent.call(cache.dataset, cache);
-      eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
+        eventCache[dataset.basisObjectId] = PREVENT_ACCUMULATIONS;
+      }
     };
 
     Dataset.setAccumulateState = function(state){

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2487,9 +2487,6 @@
       var deleted = delta.deleted;
       var cache = eventCache[datasetId];
 
-      if (cache === PREVENT_ACCUMULATIONS)
-        return;
-
       if ((inserted && deleted) || (cache && cache.mixed))
       {
         if (cache)

--- a/test/helpers/events.js
+++ b/test/helpers/events.js
@@ -8,6 +8,10 @@ function createAPI(Class){
     eventsMap[this.basisObjectId].push(event);
   };
 
+  var resetEvents = function(){
+    eventsMap = {};
+  };
+
   var getEvents = function(object, type){
     var events = eventsMap[object.basisObjectId];
 
@@ -32,6 +36,7 @@ function createAPI(Class){
   };
 
   return {
+    resetEvents: resetEvents,
     eventCount: eventCount,
     getLastEvent: getLastEvent
   };

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -330,18 +330,6 @@ module.exports = {
               }
             },
             {
-              name: 'emitting changes after destroy is noop',
-              test: function(){
-                Dataset.setAccumulateState(true);
-                objDataset.destroy();
-                objDataset.emit_itemsChanged({ inserted: [obj] });
-                Dataset.setAccumulateState(false);
-
-                assert(objDataset.getItems().length === 0);
-                assert(eventCount(objDataset, 'itemsChanged') == 1);
-              }
-            },
-            {
               name: 'add items to dataset in accumulate state before destroy',
               test: function(){
                 var existed = new DataObject({ name: 'existed' });

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -311,6 +311,8 @@ module.exports = {
                 ]
             });
 
+            // resetting events counter needed to omit counting previous events
+            // and events generated during init
             resetEvents();
           },
           test: [
@@ -422,6 +424,7 @@ module.exports = {
                 var b = new DataObject();
                 var c = new DataObject();
 
+                // resetting events counter needed to omit counting previous events
                 resetEvents();
 
                 Dataset.setAccumulateState(true);

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -338,6 +338,39 @@ module.exports = {
                 assert(objDataset.getItems().length === 0);
                 assert(eventCount(objDataset, 'itemsChanged') == 1);
               }
+            },
+            {
+              name: 'add items to dataset in accumulate state before destroy',
+              test: function(){
+                var existed = new DataObject({ name: 'existed' });
+                var added = new DataObject({ name: 'added' });
+
+                var items = [];
+
+                var dataset = new Dataset({
+                  items: [
+                    existed
+                  ],
+                  handler: {
+                    'itemsChanged': function(s, delta){
+                      if (delta.inserted)
+                        items = items.concat(delta.inserted);
+
+                      if (delta.deleted)
+                        delta.deleted.forEach(function(itemToDelete){
+                          basis.array.remove(items, itemToDelete);
+                        });
+                    }
+                  }
+                });
+
+                Dataset.setAccumulateState(true);
+                dataset.add(added);
+                dataset.destroy();
+                Dataset.setAccumulateState(false);
+
+                assert(items.length === 0);
+              }
             }
           ]
         },

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -328,18 +328,6 @@ module.exports = {
               }
             },
             {
-              name: 'emitting changes after destroy is noop',
-              test: function(){
-                Dataset.setAccumulateState(true);
-                objDataset.destroy();
-                objDataset.emit_itemsChanged({ inserted: [obj] });
-                Dataset.setAccumulateState(false);
-
-                assert(objDataset.getItems().length === 0);
-                assert(eventCount(objDataset, 'itemsChanged') == 1);
-              }
-            },
-            {
               name: 'add items to dataset in accumulate state before destroy',
               test: function(){
                 var existed = new DataObject({ name: 'existed' });

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -298,7 +298,7 @@ module.exports = {
         },
         {
           name: 'destroy inside accumulate state',
-          test: function(){
+          beforeEach: function(){
             var obj = new DataObject({
                 data: {
                   hello: 'world'
@@ -312,13 +312,34 @@ module.exports = {
             });
 
             resetEvents();
+          },
+          test: [
+            {
+              name: 'flushes event cache for dataset',
+              test: function(){
+                Dataset.setAccumulateState(true);
+                objDataset.destroy();
 
-            Dataset.setAccumulateState(true);
-            objDataset.destroy();
-            Dataset.setAccumulateState(false);
+                assert(eventCount(objDataset, 'itemsChanged') == 1);
 
-            assert(eventCount(objDataset, 'itemsChanged') == 1);
-          }
+                Dataset.setAccumulateState(false);
+
+                assert(eventCount(objDataset, 'itemsChanged') == 1);
+              }
+            },
+            {
+              name: 'emitting changes after destroy is noop',
+              test: function(){
+                Dataset.setAccumulateState(true);
+                objDataset.destroy();
+                objDataset.emit_itemsChanged({ inserted: [obj] });
+                Dataset.setAccumulateState(false);
+
+                assert(objDataset.getItems().length === 0);
+                assert(eventCount(objDataset, 'itemsChanged') == 1);
+              }
+            }
+          ]
         },
         {
           name: 'edge cases',

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -18,6 +18,7 @@ module.exports = {
 
     var helpers = basis.require('./helpers/events.js').createAPI(basis.require('basis.event').Emitter);
     var eventCount = helpers.eventCount;
+    var resetEvents = helpers.resetEvents;
   },
 
   test: [
@@ -296,6 +297,30 @@ module.exports = {
           }
         },
         {
+          name: 'destroy inside accumulate state',
+          test: function(){
+            var obj = new DataObject({
+                data: {
+                  hello: 'world'
+                }
+            });
+
+            var objDataset = new Dataset({
+                items: [
+                    obj
+                ]
+            });
+
+            resetEvents();
+
+            Dataset.setAccumulateState(true);
+            objDataset.destroy();
+            Dataset.setAccumulateState(false);
+
+            assert(eventCount(objDataset, 'itemsChanged') == 1);
+          }
+        },
+        {
           name: 'edge cases',
           test: [
             {
@@ -342,6 +367,8 @@ module.exports = {
                 var a = new DataObject();
                 var b = new DataObject();
                 var c = new DataObject();
+
+                resetEvents();
 
                 Dataset.setAccumulateState(true);
                 dataset.add([a, b, c]);

--- a/test/spec/data/dataset.js
+++ b/test/spec/data/dataset.js
@@ -328,6 +328,18 @@ module.exports = {
               }
             },
             {
+              name: 'emitting changes after destroy is noop',
+              test: function(){
+                Dataset.setAccumulateState(true);
+                objDataset.destroy();
+                objDataset.emit_itemsChanged({ inserted: [obj] });
+                Dataset.setAccumulateState(false);
+
+                assert(objDataset.getItems().length === 0);
+                assert(eventCount(objDataset, 'itemsChanged') == 1);
+              }
+            },
+            {
               name: 'add items to dataset in accumulate state before destroy',
               test: function(){
                 var existed = new DataObject({ name: 'existed' });


### PR DESCRIPTION
If dataset with items gets destroyed in accumulate state, it calls `this.clear()` which fires an `itemsChanged` event.
Because of accumulate state it gets destroyed first, and after `setAccumulateState(false)` - fired. In `emit_itemsChanged` it tries to remove deleted items from `this.items_` map, which became `null` after destroy. 
Therefore `delete this.items_[object.basisObjectId]` fires error