### PR TITLE
basis.data.dataset: Fix Merge create behavior (and some others) in accumulate state

### DIFF
--- a/src/basis/data/dataset/Merge.js
+++ b/src/basis/data/dataset/Merge.js
@@ -98,6 +98,7 @@ var MERGE_DATASET_HANDLER = {
           // register in source map
           memberMap[objectId] = {
             count: 1,
+            presented: false,
             object: object
           };
         }
@@ -244,14 +245,20 @@ var Merge = ReadOnlyDataset.subclass({
       memberCounter = memberMap[objectId];
       isMember = sourceCount && memberCounter.count && rule(memberCounter.count, sourceCount);
 
-      if (isMember != objectId in this.items_)
+      if (isMember != memberCounter.presented)
       {
         if (isMember)
+        {
           // not in items -> insert
+          memberCounter.presented = true;
           inserted.push(memberCounter.object);
+        }
         else
+        {
           // already in items -> delete
+          memberCounter.presented = false;
           deleted.push(memberCounter.object);
+        }
       }
 
       if (memberCounter.count == 0)
@@ -291,6 +298,7 @@ var Merge = ReadOnlyDataset.subclass({
         // add to source map
         memberMap[objectId] = {
           count: 1,
+          presented: false,
           object: dataset.items_[objectId]
         };
       }

--- a/src/basis/data/dataset/Merge.js
+++ b/src/basis/data/dataset/Merge.js
@@ -98,7 +98,7 @@ var MERGE_DATASET_HANDLER = {
           // register in source map
           memberMap[objectId] = {
             count: 1,
-            presented: false,
+            isMember: false,
             object: object
           };
         }
@@ -245,18 +245,18 @@ var Merge = ReadOnlyDataset.subclass({
       memberCounter = memberMap[objectId];
       isMember = sourceCount && memberCounter.count && rule(memberCounter.count, sourceCount);
 
-      if (isMember != memberCounter.presented)
+      if (isMember != memberCounter.isMember)
       {
         if (isMember)
         {
           // not in items -> insert
-          memberCounter.presented = true;
+          memberCounter.isMember = true;
           inserted.push(memberCounter.object);
         }
         else
         {
           // already in items -> delete
-          memberCounter.presented = false;
+          memberCounter.isMember = false;
           deleted.push(memberCounter.object);
         }
       }
@@ -298,7 +298,7 @@ var Merge = ReadOnlyDataset.subclass({
         // add to source map
         memberMap[objectId] = {
           count: 1,
-          presented: false,
+          isMember: false,
           object: dataset.items_[objectId]
         };
       }

--- a/test/spec/dataset/merge.js
+++ b/test/spec/dataset/merge.js
@@ -485,6 +485,28 @@ module.exports = {
                 assert(merge.has(foo) === true);
                 assert(merge.has(bar) === true);
               }
+            },
+            {
+              name: 'add and remove in accumulate state',
+              test: function(){
+                var merge = new Merge({
+                  sources: [
+                    fooDataset,
+                    barDataset
+                  ]
+                });
+                var baz = new DataObject({ data: { text: 'baz' } });
+
+                Dataset.setAccumulateState(true);
+                fooDataset.add(baz);
+                fooDataset.remove(foo);
+                Dataset.setAccumulateState(false);
+
+                assert(merge.itemCount === 2);
+                assert(merge.has(foo) === false);
+                assert(merge.has(bar) === true);
+                assert(merge.has(baz) === true);
+              }
             }
           ]
         }

--- a/test/spec/dataset/merge.js
+++ b/test/spec/dataset/merge.js
@@ -415,27 +415,25 @@ module.exports = {
         },
         {
           name: 'setAccumulateState',
+          beforeEach: function(){
+            var foo = new DataObject({ data: { text: 'foo' } });
+            var bar = new DataObject({ data: { text: 'bar' } });
+
+            var fooDataset = new Dataset({
+              items: [
+                foo
+              ]
+            });
+            var barDataset = new Dataset({
+              items: [
+                bar
+              ]
+            });
+          },
           test: [
             {
               name: 'create merge in accumulate state',
               test: function(){
-                function obj(text) {
-                  return new DataObject({ data: { text: text } });
-                }
-                var foo = obj('foo');
-                var bar = obj('bar');
-
-                var fooDataset = new Dataset({
-                  items: [
-                    foo
-                  ]
-                });
-                var barDataset = new Dataset({
-                  items: [
-                    bar
-                  ]
-                });
-
                 Dataset.setAccumulateState(true);
                 var merge = new Merge({
                   sources: [
@@ -453,23 +451,6 @@ module.exports = {
             {
               name: 'create merge and delete items in accumulate state',
               test: function(){
-                function obj(text) {
-                  return new DataObject({ data: { text: text } });
-                }
-                var foo = obj('foo');
-                var bar = obj('bar');
-
-                var fooDataset = new Dataset({
-                  items: [
-                    foo
-                  ]
-                });
-                var barDataset = new Dataset({
-                  items: [
-                    bar
-                  ]
-                });
-
                 Dataset.setAccumulateState(true);
                 var merge = new Merge({
                   sources: [
@@ -477,7 +458,6 @@ module.exports = {
                     barDataset
                   ]
                 });
-                debugger;
                 merge.setRule(Merge.INTERSECTION);
                 Dataset.setAccumulateState(false);
 
@@ -485,6 +465,26 @@ module.exports = {
                 assert(merge.has(foo) === false);
                 assert(merge.has(bar) === false);
               },
+            },
+            {
+              name: 'create merge and change rules in accumulate state',
+              test: function(){
+                var merge = new Merge({
+                  sources: [
+                    fooDataset,
+                    barDataset
+                  ]
+                });
+
+                Dataset.setAccumulateState(true);
+                merge.setRule(Merge.INTERSECTION);
+                merge.setRule(Merge.UNION);
+                Dataset.setAccumulateState(false);
+
+                assert(merge.itemCount === 2);
+                assert(merge.has(foo) === true);
+                assert(merge.has(bar) === true);
+              }
             }
           ]
         }

--- a/test/spec/dataset/merge.js
+++ b/test/spec/dataset/merge.js
@@ -14,6 +14,7 @@ module.exports = {
 
     var ReadOnlyDataset = basis.require('basis.data').ReadOnlyDataset;
     var Value = basis.require('basis.data').Value;
+    var DataObject = basis.require('basis.data').Object;
     var Dataset = basis.require('basis.data').Dataset;
     var Merge = basis.require('basis.data.dataset').Merge;
 
@@ -411,6 +412,81 @@ module.exports = {
             assert(merge.itemCount == 0);
             assert(merge.sources.length == 0);
           }
+        },
+        {
+          name: 'setAccumulateState',
+          test: [
+            {
+              name: 'create merge in accumulate state',
+              test: function(){
+                function obj(text) {
+                  return new DataObject({ data: { text: text } });
+                }
+                var foo = obj('foo');
+                var bar = obj('bar');
+
+                var fooDataset = new Dataset({
+                  items: [
+                    foo
+                  ]
+                });
+                var barDataset = new Dataset({
+                  items: [
+                    bar
+                  ]
+                });
+
+                Dataset.setAccumulateState(true);
+                var merge = new Merge({
+                  sources: [
+                    fooDataset,
+                    barDataset
+                  ]
+                });
+                Dataset.setAccumulateState(false);
+
+                assert(merge.itemCount === 2);
+                assert(merge.has(foo) === true);
+                assert(merge.has(bar) === true);
+              },
+            },
+            {
+              name: 'create merge and delete items in accumulate state',
+              test: function(){
+                function obj(text) {
+                  return new DataObject({ data: { text: text } });
+                }
+                var foo = obj('foo');
+                var bar = obj('bar');
+
+                var fooDataset = new Dataset({
+                  items: [
+                    foo
+                  ]
+                });
+                var barDataset = new Dataset({
+                  items: [
+                    bar
+                  ]
+                });
+
+                Dataset.setAccumulateState(true);
+                var merge = new Merge({
+                  sources: [
+                    fooDataset,
+                    barDataset
+                  ]
+                });
+                debugger;
+                merge.setRule(Merge.INTERSECTION);
+                Dataset.setAccumulateState(false);
+
+                assert(merge.itemCount === 0);
+                assert(merge.has(foo) === false);
+                assert(merge.has(bar) === false);
+              },
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Before this code, in case of creation Merge with multiple non-empty sources on adding every new source each already added source items were added one more time.
So for example here is the test
```javascript
{
  name: 'create merge in accumulate state',
  test: function(){
    function obj(text) {
      return new DataObject({ data: { text: text } });
    }
    var foo = obj('foo');
    var bar = obj('bar');

    var fooDataset = new Dataset({
      items: [
        foo
      ]
    });
    var barDataset = new Dataset({
      items: [
        bar
      ]
    });

    Dataset.setAccumulateState(true);
    var merge = new Merge({
      sources: [
        fooDataset,
        barDataset
      ]
    });
    Dataset.setAccumulateState(false);

    assert(merge.itemCount === 2);
    assert(merge.has(foo) === true);
    assert(merge.has(bar) === true);
  },
}
```
In this case check for itemCount will fail, because `foo` will be added two times, so dataset contents will be `[foo, foo, bar]`