### PR TITLE
basis.data.dataset: Fix Subtract behavior in accumulate state

### DIFF
--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2092,15 +2092,6 @@
     },
 
    /**
-    * Flush dataset accumulate state cache (if exists).
-    * @param {*} source
-    * @private
-    */
-    flushChanges_: function(){
-      Dataset.flushChanges(this);
-    },
-
-   /**
     * @destructor
     */
     destroy: function(){
@@ -2346,7 +2337,7 @@
     * Removes all items from dataset.
     */
     clear: function(){
-      this.flushChanges_();
+      Dataset.flushChanges(this);
 
       var deleted = this.getItems();
       var listenHandler = this.listen.item;

--- a/src/basis/data.js
+++ b/src/basis/data.js
@@ -2092,6 +2092,15 @@
     },
 
    /**
+    * Flush dataset accumulate state cache (if exists).
+    * @param {*} source
+    * @private
+    */
+    flushChanges_: function(){
+      Dataset.flushChanges(this);
+    },
+
+   /**
     * @destructor
     */
     destroy: function(){
@@ -2337,7 +2346,7 @@
     * Removes all items from dataset.
     */
     clear: function(){
-      Dataset.flushChanges(this);
+      this.flushChanges_();
 
       var deleted = this.getItems();
       var listenHandler = this.listen.item;

--- a/src/basis/data/dataset/Subtract.js
+++ b/src/basis/data/dataset/Subtract.js
@@ -4,7 +4,6 @@ var ReadOnlyDataset = require('basis.data').ReadOnlyDataset;
 var getDelta = require('./getDelta.js');
 var SUBSCRIPTION = require('../subscription.js');
 
-
 SUBSCRIPTION.addProperty('minuend');
 SUBSCRIPTION.addProperty('subtrahend');
 
@@ -16,6 +15,8 @@ var SUBTRACTDATASET_MINUEND_HANDLER = {
   itemsChanged: function(dataset, delta){
     if (!this.subtrahend)
       return;
+
+    this.flushChanges_();
 
     var newDelta = getDelta(
       /* inserted */ delta.inserted && delta.inserted.filter(datasetAbsentFilter, this.subtrahend),
@@ -35,6 +36,8 @@ var SUBTRACTDATASET_SUBTRAHEND_HANDLER = {
   itemsChanged: function(dataset, delta){
     if (!this.minuend)
       return;
+
+    this.flushChanges_();
 
     var newDelta = getDelta(
       /* inserted */ delta.deleted  && delta.deleted.filter(this.minuend.has, this.minuend),

--- a/src/basis/data/dataset/Subtract.js
+++ b/src/basis/data/dataset/Subtract.js
@@ -3,6 +3,7 @@ var resolveDataset = require('basis.data').resolveDataset;
 var ReadOnlyDataset = require('basis.data').ReadOnlyDataset;
 var getDelta = require('./getDelta.js');
 var SUBSCRIPTION = require('../subscription.js');
+var Dataset = require('basis.data').Dataset;
 
 SUBSCRIPTION.addProperty('minuend');
 SUBSCRIPTION.addProperty('subtrahend');
@@ -16,7 +17,7 @@ var SUBTRACTDATASET_MINUEND_HANDLER = {
     if (!this.subtrahend)
       return;
 
-    this.flushChanges_();
+    Dataset.flushChanges(this);
 
     var newDelta = getDelta(
       /* inserted */ delta.inserted && delta.inserted.filter(datasetAbsentFilter, this.subtrahend),
@@ -37,7 +38,7 @@ var SUBTRACTDATASET_SUBTRAHEND_HANDLER = {
     if (!this.minuend)
       return;
 
-    this.flushChanges_();
+    Dataset.flushChanges(this);
 
     var newDelta = getDelta(
       /* inserted */ delta.deleted  && delta.deleted.filter(this.minuend.has, this.minuend),

--- a/test/spec/dataset/subtract.js
+++ b/test/spec/dataset/subtract.js
@@ -434,6 +434,67 @@ module.exports = {
           }
         }
       ]
+    },
+    {
+      name: 'accumulate state',
+      beforeEach: function(){
+        var oldOne = new DataObject({ name: 'oldOne' });
+        var oldTwo = new DataObject({ name: 'oldTwo' });
+        var newOne = new DataObject({ name: 'newOne' });
+        var newTwo = new DataObject({ name: 'newTwo' });
+      },
+      test: [
+        {
+          name: 'replace fully both datasets with full intersection',
+          test: function(){
+            var oldOne = new DataObject({ name: 'oldOne' });
+            var newOne = new DataObject({ name: 'newOne' });
+            var minuend = new Dataset({
+              items: [oldOne]
+            });
+            var subtrahend = new Dataset({
+              items: [oldOne]
+            });
+            var subtract = new Subtract({
+              minuend: minuend,
+              subtrahend: subtrahend
+            });
+
+            Dataset.setAccumulateState(true);
+            subtrahend.set([newOne]);
+            minuend.set([newOne]);
+            Dataset.setAccumulateState(false);
+
+            assert([], subtract.getItems().map(basis.getter('name')));
+            assert(subtract.itemCount == 0);
+          }
+        },
+        {
+          name: 'replace fully both datasets with full intersection - different order',
+          test: function(){
+            var oldOne = new DataObject({ name: 'oldOne' });
+            var newOne = new DataObject({ name: 'newOne' });
+            var minuend = new Dataset({
+              items: [oldOne]
+            });
+            var subtrahend = new Dataset({
+              items: [oldOne]
+            });
+            var subtract = new Subtract({
+              minuend: minuend,
+              subtrahend: subtrahend
+            });
+
+            Dataset.setAccumulateState(true);
+            minuend.set([newOne]);
+            subtrahend.set([newOne]);
+            Dataset.setAccumulateState(false);
+
+            assert([], subtract.getItems().map(basis.getter('name')));
+            assert(subtract.itemCount == 0);
+          }
+        }
+      ]
     }
   ]
 };


### PR DESCRIPTION
Subtract listens to subtrahend and minuend changes and on their changes it decide to add or not items relying on items already presented in subtract and minuend/subtrahend (depending on what dataset triggered changes).

In `setAccumulateState` may rise the following error (test `replace fully both datasets with full intersection`):
* call itemsChanged on subtrahend with removal of item `A` not existed in subtract but existed in minuend -> push cache to add item `A` to subtract
* after that call itemsChanged on minuend with removal of item `A` -> does not push cache to remove item `A`, because it checks for presenting via `ReadOnlyDataset.has` method, which returns `false` for `A`, because cache not flushed yet
* flushing cache adds item `A` to subtract

Another option of error (test `replace fully both datasets with full intersection - different order`):
* call itemsChanged on minuend with adding item `B` to minuend not existed in subtract -> push cache to add item `B` to subtract
* after that call itemsChanged on subtrahend with adding item `B` -> does not push cache to remove item `B`, because it checks or presenting via `ReadOnlyDataset.has` method, which returns `false` for `B`, because cache not flushed yet
* flushing cache adds item `B` to subtract