### PR TITLE
🛠 close #108

### DIFF
--- a/src/devpanel/view/template-info/view/source.js
+++ b/src/devpanel/view/template-info/view/source.js
@@ -18,7 +18,7 @@ function colorizeFragment(color, str){
     : str;
 }
 
-var view = new Node({
+module.exports = Node.subclass({
   autoDelegate: true,
   handler: {
     update: function(sender, delta){
@@ -75,5 +75,3 @@ var view = new Node({
     }
   }
 });
-
-module.exports = view;


### PR DESCRIPTION
`SourceView` is an instance of `Node` but not a subclass of `Node`
`SourceView` is a satellite of `View`, but when inspector is closing, `SourceView` is destroying with `View`
When inspector is opening at next time, `SourceView` is already destroyed.
Now `SourceView` is subclass of `Node`, but not an instance
It will recreate `SourceView` every time when `View` will be created