### PR TITLE
devpanel: fixed memory leak

### DIFF
--- a/src/devpanel/view/template-info/globalElements.js
+++ b/src/devpanel/view/template-info/globalElements.js
@@ -2,15 +2,35 @@ var MAX_HISTORY_SIZE = 4;
 var PREFIX = '$b';
 var history = [];
 
+var ELEMENT_DESTROY_HANDLER = {
+  destroy: function(){
+    for (var position = 0; position < history.length; position++){
+      if (history[position] == this){
+        global[PREFIX + position] = history[position] = null;
+      }
+    }
+  }
+};
+
 function initGlobalElements(data){
   data.output.addHandler({
     change: function(){
-      if (!this.value.object) {
+      var addCandidate = this.value.object;
+
+      if (!addCandidate || history[0] == addCandidate){
         return;
       }
 
-      history.unshift(this.value.object);
-      history.length = MAX_HISTORY_SIZE;
+      history.unshift(addCandidate);
+      addCandidate.addHandler(ELEMENT_DESTROY_HANDLER);
+
+      if (history.length > MAX_HISTORY_SIZE){
+        var deleteCandidate = history.pop();
+
+        if (deleteCandidate){
+          deleteCandidate.removeHandler(ELEMENT_DESTROY_HANDLER);
+        }
+      }
 
       history.forEach(function(element, position){
         global[PREFIX + position] = element;

--- a/src/devpanel/view/template-info/globalElements.js
+++ b/src/devpanel/view/template-info/globalElements.js
@@ -4,11 +4,9 @@ var history = [];
 
 var ELEMENT_DESTROY_HANDLER = {
   destroy: function(){
-    for (var position = 0; position < history.length; position++){
-      if (history[position] == this){
+    for (var position = 0; position < history.length; position++)
+      if (history[position] == this)
         global[PREFIX + position] = history[position] = null;
-      }
-    }
   }
 };
 
@@ -17,19 +15,18 @@ function initGlobalElements(data){
     change: function(){
       var addCandidate = this.value.object;
 
-      if (!addCandidate || history[0] == addCandidate){
+      if (!addCandidate || history[0] == addCandidate)
         return;
-      }
 
       history.unshift(addCandidate);
       addCandidate.addHandler(ELEMENT_DESTROY_HANDLER);
 
-      if (history.length > MAX_HISTORY_SIZE){
+      if (history.length > MAX_HISTORY_SIZE)
+      {
         var deleteCandidate = history.pop();
 
-        if (deleteCandidate){
+        if (deleteCandidate)
           deleteCandidate.removeHandler(ELEMENT_DESTROY_HANDLER);
-        }
       }
 
       history.forEach(function(element, position){


### PR DESCRIPTION
If we inspect some components and these components will be destroyed then this components will be remain in window-object because devpanel can store inspection history in `$b[x]` properties.
Even if some component is destroyed `$b[x]` is storing a reference to this component and GC **can't collect** it.
This PR is fixing this case.

But we have one more case that can't be fixed by this PR:
Inspect component and then destroy its `parentNode.parentNode`
`$b0` is still storing a reference to inspected component.
The problem has a complex nature because this component is storing reference to his `parentNode` and his `parentNode` may have many others child nodes, that **should be** collected by GC after destroing they parent, but they will not be collected.

This components will be collected by GC only when we will inspect some other components because inspecting other component will shift history (it has max size)