### PR TITLE
Disabled warnings in SourceCode.css

### DIFF
--- a/basis.config
+++ b/basis.config
@@ -3,6 +3,9 @@
     "port": 8123
   },
   "build": {
+    "ignoreWarnings": [
+      "/src/basis/ui/templates/highlight/SourceCode.css"
+    ],
     "preset": {
       "devtool": {
         "file": "src/devpanel/standalone/index.html",

--- a/src/basis/ui/templates/highlight/SourceCode.css
+++ b/src/basis/ui/templates/highlight/SourceCode.css
@@ -1,6 +1,6 @@
 /* basisjs-tools:disable-warnings */
 
-  .Basis-SyntaxHighlight
+.Basis-SyntaxHighlight
   {
     border: 1px solid #E0E0E0;
     padding: 1px;

--- a/src/basis/ui/templates/highlight/SourceCode.css
+++ b/src/basis/ui/templates/highlight/SourceCode.css
@@ -1,6 +1,6 @@
 /* basisjs-tools:disable-warnings */
 
-.Basis-SyntaxHighlight
+  .Basis-SyntaxHighlight
   {
     border: 1px solid #E0E0E0;
     padding: 1px;


### PR DESCRIPTION
Temporary solution to ignore SourceCode.css warnings (till css-tree doesn't support comments)