### PR TITLE
Combobox should be closed on ESC key

### DIFF
--- a/src/basis/ui/field.js
+++ b/src/basis/ui/field.js
@@ -1169,6 +1169,12 @@
 
             event.die();
             break;
+          case event.KEY.ESC:
+            if (this.popup.visible)
+              this.hide();
+
+            event.die();
+            break;
         }
 
         this.emit_fieldKeydown(event);

--- a/src/basis/ui/field.js
+++ b/src/basis/ui/field.js
@@ -1164,11 +1164,6 @@
 
             break;
           case event.KEY.ENTER:
-            if (this.popup.visible)
-              this.hide();
-
-            event.die();
-            break;
           case event.KEY.ESC:
             if (this.popup.visible)
               this.hide();


### PR DESCRIPTION
Комбобоксы должны закрываться по нажатию ESC. Это нативное поведение браузера относительно `<select>` элементов, что весьма ожидаемо и от них.