### PR TITLE
Get rid of rempl warning

### DIFF
--- a/src/devpanel/remote.js
+++ b/src/devpanel/remote.js
@@ -34,10 +34,10 @@ function link(reactive, btValue){
 
 // init basisjs-tools
 basisjsToolsSync.onInit(function(basisjsToolsApi){
-  if (typeof basisjsToolsApi.initRemoteDevtoolAPI !== 'function')
+  if (typeof basisjsToolsApi.initRemotePublisher !== 'function')
     return;
 
-  var remoteApi = basisjsToolsApi.initRemoteDevtoolAPI({
+  var remoteApi = basisjsToolsApi.initRemotePublisher({
     getInspectorUI: basisjsToolsApi.getInspectorUI
   });
 


### PR DESCRIPTION
Basis.js has old version of `initRemoteDevtoolAPI` which makes tools crash (it has incorrect `initRemoteDevtoolAPI` method). 

One way to avoid this is to apply proposed changes - use `initRemotePublisher` method