### PR TITLE
Callback removal warning fix.

### DIFF
--- a/src/basis/router.js
+++ b/src/basis/router.js
@@ -761,9 +761,9 @@
 
         return;
       }
-
-      /** @cut */ basis.dev.warn(namespace + ': no callback removed', { callback: callback, context: context });
     }
+    
+    /** @cut */ basis.dev.warn(namespace + ': no callback removed', { callback: callback, context: context });
   }
 
  /**

--- a/src/basis/router.js
+++ b/src/basis/router.js
@@ -762,7 +762,6 @@
         return;
       }
     }
-    
     /** @cut */ basis.dev.warn(namespace + ': no callback removed', { callback: callback, context: context });
   }
 


### PR DESCRIPTION
Wrong placement for "no callback removed" warning. It's similar to https://github.com/basisjs/basisjs/issues/151.