### PR TITLE
Skip disabled fields on form submission

### DIFF
--- a/src/basis/ui/form.js
+++ b/src/basis/ui/form.js
@@ -92,7 +92,7 @@
       var error;
 
       for (var i = 0, field; field = this.childNodes[i]; i++)
-        if (error = field.validate())
+        if (!field.isDisabled() && (error = field.validate()))
           errors.push(error);
 
       if (errors.length)
@@ -105,7 +105,7 @@
     },
     serialize: function(){
       return this.childNodes.reduce(function(result, field){
-        if (field.serializable && field.name)
+        if (field.serializable && field.name && !field.isDisabled())
           result[field.name] = field.getValue();
 
         return result;


### PR DESCRIPTION
Apparently disabled fields should not be [validated](https://www.w3.org/TR/html5/sec-forms.html#ref-for-barred-from-constraint-validation%E2%91%A6) and [serialized](https://www.w3.org/TR/html5/sec-forms.html#constructing-the-form-data-set) on form submission (like in native HTML-forms).